### PR TITLE
Optional env in health-check path

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const _ = require('lodash'),
   os = require('os'),
   fs = require('fs'),
   yaml = require('js-yaml'),
-  healthPath = process.env.HEALTH_CHECK ? `${process.env.HEALTH_CHECK}/health-check` : 'health-check';
+  healthRoute = process.env.HEALTH_CHECK_PATH ? `${process.env.HEALTH_CHECK_PATH}/health-check` : 'health-check';
 
 /**
  * @param {string} filename
@@ -100,7 +100,7 @@ function routes(options) {
     }
   });
 
-  router.get('/' + healthPath, renderHealth(stats));
+  router.get('/' + healthRoute, renderHealth(stats));
 
   return router;
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ const _ = require('lodash'),
   v8 = require('v8'),
   os = require('os'),
   fs = require('fs'),
-  yaml = require('js-yaml');
+  yaml = require('js-yaml'),
+  healthPath = process.env.HEALTH_CHECK ? `${process.env.HEALTH_CHECK}/health-check` : 'health-check'
+
+  console.log(healthPath);
 
 /**
  * @param {string} filename
@@ -99,7 +102,7 @@ function routes(options) {
     }
   });
 
-  router.get('/health-check', renderHealth(stats));
+  router.get('/' + healthPath, renderHealth(stats));
 
   return router;
 }

--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ const _ = require('lodash'),
   os = require('os'),
   fs = require('fs'),
   yaml = require('js-yaml'),
-  healthPath = process.env.HEALTH_CHECK ? `${process.env.HEALTH_CHECK}/health-check` : 'health-check'
-
-  console.log(healthPath);
+  healthPath = process.env.HEALTH_CHECK ? `${process.env.HEALTH_CHECK}/health-check` : 'health-check';
 
 /**
  * @param {string} filename


### PR DESCRIPTION
> AWS' ELB health check does not use a hostname for its health check. It is essentially a curl on http://<ipofinstance>/<givenfilename>. This causes a problem for microservices (or any instance with more then one service) because both services can't use a single /health-check.

https://trello.com/c/jKIbXaRW/1426-add-optional-alternate-path-name-to-health-check